### PR TITLE
Improve SERFF parser clarity and resilience

### DIFF
--- a/main
+++ b/main
@@ -12,28 +12,29 @@
  */
 
 // ---------- constants & helpers ------------------------------------------
-const FIELD_LABELS = [
-  'CompanyName',
-  'Overall %IndicatedChange',
-  'Overall %RateImpact',
-  'Written PremiumChange for this Program',
-  'Number of PolicyHolders Affected for this Program',
-  'WrittenPremium for this Program',
-  "Maximum %Change(where req'd)",
-  "Minimum %Change(where req'd)",
-];
-const FIELD_RULES = FIELD_LABELS.map(l => ({
-  key  : l.toLowerCase().replace(/[^a-z0-9]+/g, ''),
+const CONFIG = {
+  fieldLabels: [
+    'CompanyName',
+    'Overall %IndicatedChange',
+    'Overall %RateImpact',
+    'Written PremiumChange for this Program',
+    'Number of PolicyHolders Affected for this Program',
+    'WrittenPremium for this Program',
+    "Maximum %Change(where req'd)",
+    "Minimum %Change(where req'd)",
+  ],
+  footerRe: /^PDF Pipeline for SERFF Tracking Number .* Generated .*$/im,
+  endMarkers: [
+    'general information', 'rate information', 'company rate information',
+    'pdf pipeline', 'disposition',
+  ],
+  keyOnlyRe: /^([\w %()\-.+'/#]+):\s*$/,
+  keyInlineRe: /^([\w %()\-.+'/#]+):\s*(.*)$/,
+};
+CONFIG.fieldRules = CONFIG.fieldLabels.map(l => ({
+  key: l.toLowerCase().replace(/[^a-z0-9]+/g, ''),
   label: l,
 }));
-
-const FOOTER_RE   = /^PDF Pipeline for SERFF Tracking Number .* Generated .*$/im;
-const END_MARKERS = [
-  'general information', 'rate information', 'company rate information',
-  'pdf pipeline', 'disposition',
-];
-const KEY_ONLY_RE   = /^([\w %()\-.+'/#]+):\s*$/;
-const KEY_INLINE_RE = /^([\w %()\-.+'/#]+):\s*(.*)$/;
 const norm = s => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
 
 // heuristics --------------------------------------------------------------
@@ -43,23 +44,35 @@ const looksTracking = v => /^[A-Z]{2,}-\d{6,}/.test(v.trim());
 
 // ---------- generic key:value parser -------------------------------------
 function parseSection(lines) {
-  const out = {}; let lastKey = null;
+  const out = {};
+  let lastKey = null;
   for (let i = 0; i < lines.length; i++) {
-    const raw = lines[i].trim(); if (!raw) continue;
-    const inl = KEY_INLINE_RE.exec(raw);
-    const keyOnly = !inl && KEY_ONLY_RE.exec(raw);
+    const line = lines[i].trim();
+    if (!line) continue;
 
-    if (inl) {
-      const [, k, v] = inl; const nk = norm(k);
-      out[nk] = v.trim(); lastKey = nk;
-    } else if (keyOnly) {
-      const key = keyOnly[1].trim(); const nk = norm(key);
-      let j = i + 1; while (j < lines.length && !lines[j].trim()) j++;
-      const isHeader = KEY_ONLY_RE.test(lines[j]);
-      const val = (j < lines.length && !isHeader) ? lines[j].trim() : '';
-      out[nk] = val; lastKey = nk; i = j;
-    } else if (lastKey) {
-      out[lastKey] = (out[lastKey] + '\n' + raw).trim();
+    const inline = CONFIG.keyInlineRe.exec(line);
+    if (inline) {
+      const [, k, v] = inline;
+      lastKey = norm(k);
+      out[lastKey] = v.trim();
+      continue;
+    }
+
+    const keyOnly = CONFIG.keyOnlyRe.exec(line);
+    if (keyOnly) {
+      const nk = norm(keyOnly[1]);
+      let j = i + 1;
+      while (j < lines.length && !lines[j].trim()) j++;
+      const next = lines[j] ? lines[j].trim() : '';
+      const isHeader = CONFIG.keyOnlyRe.test(next);
+      out[nk] = (next && !isHeader) ? next : '';
+      lastKey = nk;
+      i = j;
+      continue;
+    }
+
+    if (lastKey) {
+      out[lastKey] = (out[lastKey] + '\n' + line).trim();
     }
   }
   return out;
@@ -72,16 +85,19 @@ function parseCompanyRateRows(block) {
   if (start === -1) return [];
   const vals = lines.slice(start);
 
-  const rows = []; const CHUNK = FIELD_LABELS.length;
+  const rows = [];
+  const CHUNK = CONFIG.fieldLabels.length;
   for (let i = 0; i + CHUNK - 1 < vals.length; i += CHUNK) {
     const slice = vals.slice(i, i + CHUNK);
     const first = slice[0];
 
-    // stop if we clearly reached a footer/header or misaligned chunk
-    if (!looksCompany(first) || looksTracking(first) || /^company$/i.test(first)) break;
+    // skip clearly invalid chunks but continue parsing
+    if (!looksCompany(first) || looksTracking(first) || /^company$/i.test(first)) {
+      continue;
+    }
 
     const obj = {};
-    slice.forEach((v, idx) => obj[FIELD_RULES[idx].key] = v || '');
+    slice.forEach((v, idx) => obj[CONFIG.fieldRules[idx].key] = v || '');
     rows.push(obj);
   }
   return rows;
@@ -105,16 +121,19 @@ function parseTop(text) {
 // ---------- core extractor -----------------------------------------------
 function extractSERFF(text) {
   const cleaned = text
-    .split('\n').filter(l => !FOOTER_RE.test(l)).join('\n')
+    .split('\n')
+    .filter(l => !CONFIG.footerRe.test(l))
+    .join('\n')
     .replace(/SERFF Tracking #:[\s\S]*?\n\s*\n/g, '');
-  const lines = cleaned.split('\n');
+  const lines = cleaned.split('\n').map(l => l.trim());
 
   // Filing‑at‑a‑Glance ------------------------------------------------------
-  const glaIdx = lines.findIndex(l => /^filing at a glance$/i.test(l.trim()));
+  const glaIdx = lines.findIndex(l => /^filing at a glance$/i.test(l));
   if (glaIdx === -1) throw new Error('Missing Filing at a Glance');
   const glaLines = [];
   for (let i = glaIdx + 1; i < lines.length; i++) {
-    const t = lines[i].trim().toLowerCase(); if (END_MARKERS.includes(t)) break;
+    const t = lines[i].toLowerCase();
+    if (CONFIG.endMarkers.includes(t)) break;
     glaLines.push(lines[i]);
   }
   const filingAtGlance = parseSection(glaLines);
@@ -127,11 +146,12 @@ function extractSERFF(text) {
   const startRI = txtLower.indexOf('rate data applies to filing');
   if (startRI === -1) throw new Error('Missing Rate Info');
   let endRI = cleaned.length;
-  END_MARKERS.forEach(m => {
+  CONFIG.endMarkers.forEach(m => {
     const i = txtLower.indexOf(m, startRI + 1);
     if (i !== -1 && i < endRI) endRI = i;
   });
   const rateBlock = cleaned.slice(startRI, endRI);
+  const riLineIdx = lines.findIndex(l => /rate data applies to filing/i.test(l));
   const RATE_KEYS = [
     'Filing Method',
     'Rate Change Type',
@@ -149,13 +169,13 @@ function extractSERFF(text) {
   });
 
   // Company Rate Information ----------------------------------------------
-  const afterRI = lines.slice(lines.findIndex((l,i)=>/rate data applies to filing/i.test(l)) + 1);
-  const crIdx = afterRI.findIndex(l => /^company rate information$/i.test(l.trim()));
+  const afterRI = lines.slice(riLineIdx + 1);
+  const crIdx = afterRI.findIndex(l => /^company rate information$/i.test(l));
   if (crIdx === -1) return { common:{topOfPage:parseTop(text), filingAtGlance, rateInformation}, rows: [] };
   const crLines = [];
   for (let i = crIdx + 1; i < afterRI.length; i++) {
-    const t = afterRI[i].trim().toLowerCase();
-    if (END_MARKERS.includes(t) || /^serff tracking #:?/i.test(t)) break;
+    const t = afterRI[i].toLowerCase();
+    if (CONFIG.endMarkers.includes(t) || /^serff tracking #:?/i.test(t)) break;
     crLines.push(afterRI[i]);
   }
   const rows = parseCompanyRateRows(crLines.join('\n'));
@@ -174,7 +194,7 @@ items.forEach(item => {
       out.push({ json: { ...common.topOfPage, ...common.filingAtGlance, ...common.rateInformation, parse_warning: 'No Company Rate rows found' } });
     }
   } catch (err) {
-    out.push({ json: { parse_error: err.message } });
+    out.push({ json: { parse_error: err.message, snippet: (item.json.text || '').slice(0, 100) } });
   }
 });
 


### PR DESCRIPTION
## Summary
- centralize configuration for the parser
- streamline section parsing
- skip invalid company blocks instead of stopping early
- trim lines once and reuse the Rate Info index
- add parsing context when errors occur

## Testing
- `node run.js` *(produced output from testinput.json)*