### PR TITLE
Fix parseCompanyRateRows scanning

### DIFF
--- a/main
+++ b/main
@@ -91,9 +91,9 @@ function parseCompanyRateRows(block) {
     const slice = vals.slice(i, i + CHUNK);
     const first = slice[0];
 
-    // skip clearly invalid chunks but continue parsing
+    // stop scanning once we hit something that doesn't look like a company
     if (!looksCompany(first) || looksTracking(first) || /^company$/i.test(first)) {
-      continue;
+      break;
     }
 
     const obj = {};


### PR DESCRIPTION
## Summary
- stop scanning company rows after encountering a non-company chunk

## Testing
- `node --check main`