### PR TITLE
Improve row validation using percent heuristic

### DIFF
--- a/main
+++ b/main
@@ -87,12 +87,17 @@ function parseCompanyRateRows(block) {
 
   const rows = [];
   const CHUNK = CONFIG.fieldLabels.length;
+  const PERCENT_COLS = [1, 2, 6, 7];
   for (let i = 0; i + CHUNK - 1 < vals.length; i += CHUNK) {
     const slice = vals.slice(i, i + CHUNK);
     const first = slice[0];
 
     // skip clearly invalid chunks but continue parsing
     if (!looksCompany(first) || looksTracking(first) || /^company$/i.test(first)) {
+      continue;
+    }
+
+    if (PERCENT_COLS.some(idx => slice[idx] && !looksPercent(slice[idx]))) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- add checks for percent-like values when parsing company rows

## Testing
- `node - <<'EOF'
const fs=require('fs');
const j=JSON.parse(fs.readFileSync('testinput.json','utf8')); 
const items=j.map(it=>({json:{text:it.text}}));
const code=fs.readFileSync('main','utf8');
const vm=require('vm');
const Fn=vm.runInNewContext('(function(){\n'+code+'\nreturn out;\n})', {items, console});
const out=Fn();
console.log('out count', out.length);
console.log(Object.keys(out[0].json).slice(0,5));
EOF`