### PR TITLE
Fix parsing for company rate rows with combined first line

### DIFF
--- a/main
+++ b/main
@@ -109,10 +109,10 @@ function parseSection(lines) {
 
 // ---------- Company Rate block ➜ row objects -----------------------------
 function parseCompanyRateRows(block) {
-  const lines = block.split('\n').map(l => l.trim()).filter(Boolean);
-  const start = lines.findIndex(l => !l.endsWith(':'));
+  const rawLines = block.split('\n').map(l => l.trim());
+  const start = rawLines.findIndex(l => l && !l.endsWith(':'));
   if (start === -1) return [];
-  const vals = lines.slice(start);
+  const vals = rawLines.slice(start).filter(Boolean);
 
   const rows = [];
   const CHUNK = CONFIG.fieldLabels.length;
@@ -136,10 +136,17 @@ function parseCompanyRateRows(block) {
   }
 
   if (!rows.length) {
-    const raw = block.split('\n').map(l => l.trim());
-    const first = raw.findIndex(l => l && !l.endsWith(':'));
-    if (first !== -1 && raw.length >= first + CHUNK) {
-      const slice = raw.slice(first, first + CHUNK);
+    const trimmed = rawLines.slice(start).filter(Boolean);
+    if (trimmed.length === CHUNK - 1) {
+      const m = trimmed[0].match(/^(.*?\S)\s+(-?\d.*%?)$/);
+      if (m) {
+        const tokens = [m[1], m[2], ...trimmed.slice(1)];
+        const obj = {};
+        tokens.forEach((v, idx) => obj[CONFIG.fieldRules[idx].key] = v || '');
+        if (Object.values(obj).some(v => v)) rows.push(obj);
+      }
+    } else if (trimmed.length >= CHUNK) {
+      const slice = trimmed.slice(0, CHUNK);
       const obj = {};
       slice.forEach((v, idx) => obj[CONFIG.fieldRules[idx].key] = v || '');
       if (Object.values(obj).some(v => v)) rows.push(obj);


### PR DESCRIPTION
## Summary
- improve row handling when the first value line contains two fields

## Testing
- `node -e "const fs=require('fs');const items=JSON.parse(fs.readFileSync('testinput.json','utf8')).map(o=>({json:o}));const script=fs.readFileSync('./main','utf8');const run=new Function('items',script);console.log(JSON.stringify(run(items),null,2));" > output.json`
- `node -e "const fs=require('fs');const items=JSON.parse(fs.readFileSync('testinput_disapproved.json','utf8')).map(o=>({json:o}));const script=fs.readFileSync('./main','utf8');const run=new Function('items',script);console.log(JSON.stringify(run(items),null,2));" > output_dis.json`
