### PR TITLE
Fix company row parsing with trailing lines

### DIFF
--- a/main
+++ b/main
@@ -109,13 +109,22 @@ function parseSection(lines) {
 
 // ---------- Company Rate block ➜ row objects -----------------------------
 function parseCompanyRateRows(block) {
-  const lines = block.split('\n').map(l => l.trim()).filter(Boolean);
-  const start = lines.findIndex(l => !l.endsWith(':'));
+  const raw = block.split('\n').map(l => l.trim());
+  const start = raw.findIndex(l => l && !l.endsWith(':'));
   if (start === -1) return [];
-  const vals = lines.slice(start);
-
-  const rows = [];
+  let vals = [];
+  for (let i = start; i < raw.length; i++) {
+    const line = raw[i];
+    if (!line) continue;
+    if (line.endsWith(':')) break; // stop at next header
+    vals.push(line);
+  }
   const CHUNK = CONFIG.fieldLabels.length;
+  if (vals.length >= CHUNK - 1) {
+    const m = vals[0].match(/^(.*?\S)\s+(-?\d.*%?)$/);
+    if (m) vals = [m[1], m[2], ...vals.slice(1)];
+  }
+  const rows = [];
   const PERCENT_COLS = [1, 2, 6, 7];
   for (let i = 0; i + CHUNK - 1 < vals.length; i += CHUNK) {
     const slice = vals.slice(i, i + CHUNK);
@@ -136,10 +145,17 @@ function parseCompanyRateRows(block) {
   }
 
   if (!rows.length) {
-    const raw = block.split('\n').map(l => l.trim());
-    const first = raw.findIndex(l => l && !l.endsWith(':'));
-    if (first !== -1 && raw.length >= first + CHUNK) {
-      const slice = raw.slice(first, first + CHUNK);
+    const trimmed = vals.slice();
+    if (trimmed.length === CHUNK - 1) {
+      const m = trimmed[0].match(/^(.*?\S)\s+(-?\d.*%?)$/);
+      if (m) {
+        const tokens = [m[1], m[2], ...trimmed.slice(1)];
+        const obj = {};
+        tokens.forEach((v, idx) => obj[CONFIG.fieldRules[idx].key] = v || '');
+        if (Object.values(obj).some(v => v)) rows.push(obj);
+      }
+    } else if (trimmed.length >= CHUNK) {
+      const slice = trimmed.slice(0, CHUNK);
       const obj = {};
       slice.forEach((v, idx) => obj[CONFIG.fieldRules[idx].key] = v || '');
       if (Object.values(obj).some(v => v)) rows.push(obj);


### PR DESCRIPTION
## Summary
- stop parsing company rate values at the next header line
- split combined company/percent values before row processing

## Testing
- `node -e "const fs=require('fs');const items=JSON.parse(fs.readFileSync('testinput.json','utf8')).map(o=>({json:o}));const script=fs.readFileSync('./main','utf8');const run=new Function('items',script);console.log(JSON.stringify(run(items),null,2));" > output.json`
- `node -e "const fs=require('fs');const items=JSON.parse(fs.readFileSync('testinput_disapproved.json','utf8')).map(o=>({json:o}));const script=fs.readFileSync('./main','utf8');const run=new Function('items',script);console.log(JSON.stringify(run(items),null,2));" > output_dis.json`
- `node -e "const fs=require('fs');const items=JSON.parse(fs.readFileSync('testinput2.json','utf8')).map(o=>({json:o}));const script=fs.readFileSync('./main','utf8');const run=new Function('items',script);console.log(JSON.stringify(run(items),null,2));" > output2.json`