### PR TITLE
Fix parser bug and add batch test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,16 @@ The command reads the JSON from `testinput.json`, processes the file, and writes
 an array of objects to `output.json`. Each object represents data extracted for
 a company in the input PDF. If the parser encounters an error, the output will
 contain a single item with `parse_error` describing the issue.
+
+### Batch testing
+
+To run the parser against multiple input files at once, use the provided
+`batch_test.js` script. Pass one or more JSON files containing the extracted
+text as arguments:
+
+```bash
+node batch_test.js testinput.json testinput2.json testinput_disapproved.json
+```
+
+The script writes a corresponding `*.out.json` file for each input and prints a
+summary of the processed files.

--- a/batch_test.js
+++ b/batch_test.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+
+const script = fs.readFileSync('./main', 'utf8');
+const run = new Function('items', script);
+
+if (process.argv.length <= 2) {
+  console.error('Usage: node batch_test.js <input1.json> [input2.json ...]');
+  process.exit(1);
+}
+
+for (const file of process.argv.slice(2)) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const items = data.map(o => ({ json: o }));
+  const out = run(items);
+  const outPath = file.replace(/\.json$/, '') + '.out.json';
+  fs.writeFileSync(outPath, JSON.stringify(out, null, 2));
+  console.log(`Processed ${file} -> ${outPath}`);
+}

--- a/main
+++ b/main
@@ -110,6 +110,12 @@ function parseSection(lines) {
 // ---------- Company Rate block ➜ row objects -----------------------------
 function parseCompanyRateRows(block) {
   const CHUNK = CONFIG.fieldLabels.length;
+  let vals = String(block)
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean);
+  const trimmed = vals.slice();
+
   if (vals.length >= CHUNK - 1) {
     const m = vals[0].match(/^(.*?\S)\s+(-?\d.*%?)$/);
     if (m) vals = [m[1], m[2], ...vals.slice(1)];


### PR DESCRIPTION
## Summary
- fix `parseCompanyRateRows` so internal variables are defined
- add `batch_test.js` to run the parser on multiple inputs
- document batch testing instructions in README

## Testing
- `node batch_test.js testinput.json testinput2.json testinput_disapproved.json`