### PR TITLE
Handle header rows in company rate info

### DIFF
--- a/main
+++ b/main
@@ -114,6 +114,13 @@ function parseCompanyRateRows(block) {
     .split('\n')
     .map(l => l.trim())
     .filter(Boolean);
+  const maybeHeader = vals.slice(0, CHUNK)
+    .map(v => v.replace(/:+$/, ''))
+    .map(v => norm(v));
+  const expected = CONFIG.fieldRules.map(fr => fr.key);
+  if (maybeHeader.length === CHUNK && expected.every((e, i) => maybeHeader[i] === e)) {
+    vals = vals.slice(CHUNK);
+  }
   const trimmed = vals.slice();
 
   if (vals.length >= CHUNK - 1) {


### PR DESCRIPTION
## Summary
- ignore header labels when parsing Company Rate Information rows

## Testing
- `node batch_test.js testinput.json testinput2.json testinput_disapproved.json`
- `node - <<'NODE'
const fs=require('fs');
const script=fs.readFileSync('./main','utf8');
const start=script.indexOf('const CONFIG');
const end=script.indexOf('// ---------- rate helpers');
const code=script.slice(start,end);
const vm=require('vm');
const ctx={};
vm.createContext(ctx);
vm.runInContext(code, ctx);
const parse=ctx.parseCompanyRateRows;
const text=fs.readFileSync('testinput-fail-1','utf8');
const block=text.split('Company Rate Information')[1].split(/SERFF Tracking/i)[0];
const rows=parse(block);
console.log(JSON.stringify(rows, null, 2));
NODE